### PR TITLE
Use SwiftPM to generate xcodeproj and run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
       #     gem install bundler
       #     bundle install --without=documentation --jobs 4 --retry 3
 
-      - name: Generate xcodeproj SwiftPM
+      - name: Generate xcodeproj
         run: swift package generate-xcodeproj
-      - name: iOS - ${{ matrix.destination }}
+      - name: Test on iOS ${{ matrix.destination }}
         run: |
           set -o pipefail
           xcodebuild clean test -project "$PROJECT" -scheme "$SCHEME" -sdk "$IOS_SDK" -destination "${{ matrix.destination }}" -enableCodeCoverage YES -configuration Debug ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | xcpretty -c;


### PR DESCRIPTION
Adds a step to generate the xcodeproj in ci.yml, so that we can use xcodebuild to run tests.