### PR TITLE
[CI] Test SPM integration in isolation

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -11,7 +11,6 @@ on:
       - dev
 env:
   DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
-  PROJECT: ReactiveCollectionsKit.xcodeproj
   SCHEME: ReactiveCollectionsKit
   IOS_SDK: iphonesimulator13.2
 
@@ -20,9 +19,6 @@ jobs:
   iOS:
     name: iOS Test
     runs-on: macOS-latest
-    strategy:
-      matrix:
-        destination: ["OS=13.2,name=iPhone 11"]
     steps:
       - name: git checkout
         uses: actions/checkout@v1
@@ -30,10 +26,10 @@ jobs:
       - name: xcode version
         run: xcodebuild -version -sdk
 
-      - name: Generate xcodeproj
+      - name: SPM generate xcodeproj
         run: swift package generate-xcodeproj
 
-      - name: Test - ${{ matrix.destination }}
+      - name: Test
         run: |
           set -o pipefail
-          xcodebuild clean test -scheme "$SCHEME" -sdk "$IOS_SDK" -destination "${{ matrix.destination }}" | xcpretty -c;
+          xcodebuild clean test -scheme "$SCHEME" -sdk "$IOS_SDK" -destination 'name=iPhone 11' | xcpretty -c;


### PR DESCRIPTION
Following up on #8.

I think if we make SPM a separate CI workflow, we can achieve what we want: testing SPM integration in isolation. I want to make sure that we don't break SPM support somehow in the future.

Ref: Issue #6.