### PR TITLE
Rework view model updates

### DIFF
--- a/Example/Sources/FlowLayout/SimpleFlowLayoutViewController.swift
+++ b/Example/Sources/FlowLayout/SimpleFlowLayoutViewController.swift
@@ -62,6 +62,6 @@ final class SimpleFlowLayoutViewController: UICollectionViewController {
 
         let collectionViewModel = CollectionViewModel(id: "static_flow_layout", sections: [section])
 
-        self.driver.viewModel = collectionViewModel
+        self.driver.update(viewModel: collectionViewModel)
     }
 }

--- a/Example/Sources/Grid/GridViewController.swift
+++ b/Example/Sources/Grid/GridViewController.swift
@@ -20,15 +20,16 @@ final class GridViewController: ExampleViewController, CellEventCoordinator {
         view: self.collectionView,
         emptyViewProvider: sharedEmptyViewProvider,
         cellEventCoordinator: self
-    ) {
-        print("grid did update!")
-        print($0.viewModel)
-    }
+    )
 
     override var model: Model {
         didSet {
             // Every time the model updates, regenerate and set the view model
-            self.driver.viewModel = self.makeViewModel()
+            let viewModel = self.makeViewModel()
+            self.driver.update(viewModel: viewModel, animated: true) {
+                print("grid did update!")
+                print($0.viewModel)
+            }
         }
     }
 
@@ -42,7 +43,8 @@ final class GridViewController: ExampleViewController, CellEventCoordinator {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.driver.viewModel = self.makeViewModel()
+        let viewModel = self.makeViewModel()
+        self.driver.update(viewModel: viewModel)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Example/Sources/List/ListViewController.swift
+++ b/Example/Sources/List/ListViewController.swift
@@ -21,15 +21,16 @@ final class ListViewController: ExampleViewController, CellEventCoordinator {
         view: self.collectionView,
         emptyViewProvider: sharedEmptyViewProvider,
         cellEventCoordinator: self
-    ) {
-        print("list did update!")
-        print($0.viewModel)
-    }
+    )
 
     override var model: Model {
         didSet {
             // Every time the model updates, regenerate and set the view model
-            self.driver.viewModel = self.makeViewModel()
+            let viewModel = self.makeViewModel()
+            self.driver.update(viewModel: viewModel, animated: true) {
+                print("list did update!")
+                print($0.viewModel)
+            }
         }
     }
 
@@ -59,7 +60,8 @@ final class ListViewController: ExampleViewController, CellEventCoordinator {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.driver.viewModel = self.makeViewModel()
+        let viewModel = self.makeViewModel()
+        self.driver.update(viewModel: viewModel)
 
         self.driver.$viewModel
             .sink { _ in

--- a/Example/Sources/SimpleStatic/SimpleStaticViewController.swift
+++ b/Example/Sources/SimpleStatic/SimpleStaticViewController.swift
@@ -55,6 +55,6 @@ final class SimpleStaticViewController: UICollectionViewController {
 
         let collectionViewModel = CollectionViewModel(id: "static_view", sections: [section])
 
-        self.driver.viewModel = collectionViewModel
+        self.driver.update(viewModel: collectionViewModel)
     }
 }

--- a/README.md
+++ b/README.md
@@ -56,15 +56,9 @@ let section = SectionViewModel(id: "my_section", cells: cellViewModels)
 // create the collection with sections
 let collectionViewModel = CollectionViewModel(sections: [section])
 
-// create the layout
-let layout = UICollectionViewCompositionalLayout.list(
-    using: .init(appearance: .insetGrouped)
-)
-
 // initialize the driver with the view model and other components
 let driver = CollectionViewDriver(
     view: collectionView,
-    layout: layout,
     viewModel: collectionViewModel,
     emptyViewProvider: provider,
     cellEventCoordinator: coordinator
@@ -73,8 +67,8 @@ let driver = CollectionViewDriver(
 // the collection view is updated and animated automatically
 
 // when the models change, generate a new view model (like above)
-let updatedCollectionViewModel = CollectionViewModel(sections: [/* updated items and sections */])
-driver.viewModel = updatedCollectionViewModel
+let updated = CollectionViewModel(sections: [/* updated items and sections */])
+driver.update(viewModel: updated)
 ```
 
 ## Requirements

--- a/Sources/CollectionViewDriverOptions.swift
+++ b/Sources/CollectionViewDriverOptions.swift
@@ -15,11 +15,6 @@ import Foundation
 
 /// Defines various options to customize behavior of a ``CollectionViewDriver``.
 public struct CollectionViewDriverOptions: Hashable {
-
-    /// Returns whether or not to animate updates.
-    /// Pass `true` to animate, `false` otherwise.
-    public let animateUpdates: Bool
-
     /// Specifies whether or not to perform diffing on a background queue.
     /// Pass `true` to perform diffing in the background,
     /// pass `false` to perform diffing on the main thread.
@@ -36,15 +31,12 @@ public struct CollectionViewDriverOptions: Hashable {
     /// Initializes a `CollectionViewDriverOptions` object.
     ///
     /// - Parameters:
-    ///   - animateUpdates: Whether or not to animate updates. Default is `true`.
     ///   - diffOnBackgroundQueue: Whether or not to perform diffing on a background queue. Default is `false`.
     ///   - reloadDataOnReplacingViewModel: Whether or not to reload or diff during replacement. Default is `false`.
     public init(
-        animateUpdates: Bool = true,
         diffOnBackgroundQueue: Bool = false,
         reloadDataOnReplacingViewModel: Bool = false
     ) {
-        self.animateUpdates = animateUpdates
         self.diffOnBackgroundQueue = diffOnBackgroundQueue
         self.reloadDataOnReplacingViewModel = reloadDataOnReplacingViewModel
     }

--- a/Tests/TestCollectionViewDriver.swift
+++ b/Tests/TestCollectionViewDriver.swift
@@ -26,8 +26,7 @@ final class TestCollectionViewDriver: UnitTestCase {
             viewModel: model,
             options: .test(),
             emptyViewProvider: nil,
-            cellEventCoordinator: nil,
-            didUpdate: nil
+            cellEventCoordinator: nil
         )
 
         XCTAssertEqual(driver.numberOfSections, sections)
@@ -45,8 +44,7 @@ final class TestCollectionViewDriver: UnitTestCase {
             view: self.collectionView,
             options: .test(),
             emptyViewProvider: nil,
-            cellEventCoordinator: nil,
-            didUpdate: nil
+            cellEventCoordinator: nil
         )
 
         XCTAssertEqual(driver.numberOfSections, .zero)
@@ -64,8 +62,7 @@ final class TestCollectionViewDriver: UnitTestCase {
             viewModel: model,
             options: .test(),
             emptyViewProvider: nil,
-            cellEventCoordinator: nil,
-            didUpdate: nil
+            cellEventCoordinator: nil
         )
 
         for section in 0..<sections {
@@ -92,8 +89,7 @@ final class TestCollectionViewDriver: UnitTestCase {
             viewModel: collection,
             options: .test(),
             emptyViewProvider: nil,
-            cellEventCoordinator: nil,
-            didUpdate: nil
+            cellEventCoordinator: nil
         )
 
         let highlight1 = driver.collectionView(self.collectionView, shouldHighlightItemAt: .init(item: 0, section: 0))
@@ -118,8 +114,7 @@ final class TestCollectionViewDriver: UnitTestCase {
             viewModel: collection,
             options: .test(),
             emptyViewProvider: nil,
-            cellEventCoordinator: nil,
-            didUpdate: nil
+            cellEventCoordinator: nil
         )
 
         let menu1 = driver.collectionView(
@@ -151,8 +146,7 @@ final class TestCollectionViewDriver: UnitTestCase {
             viewModel: model,
             options: .test(),
             emptyViewProvider: nil,
-            cellEventCoordinator: nil,
-            didUpdate: nil
+            cellEventCoordinator: nil
         )
         self.simulateViewControllerAppearance()
 
@@ -198,8 +192,7 @@ final class TestCollectionViewDriver: UnitTestCase {
             viewModel: collection,
             options: .test(),
             emptyViewProvider: nil,
-            cellEventCoordinator: nil,
-            didUpdate: nil
+            cellEventCoordinator: nil
         )
         self.simulateViewControllerAppearance()
 

--- a/Tests/TestCollectionViewDriverOptions.swift
+++ b/Tests/TestCollectionViewDriverOptions.swift
@@ -18,7 +18,6 @@ final class TestCollectionViewDriverOptions: XCTestCase {
 
     func test_defaultValues() {
         let options = CollectionViewDriverOptions()
-        XCTAssertTrue(options.animateUpdates)
         XCTAssertFalse(options.diffOnBackgroundQueue)
         XCTAssertFalse(options.reloadDataOnReplacingViewModel)
     }

--- a/Tests/TestEmptyView.swift
+++ b/Tests/TestEmptyView.swift
@@ -40,8 +40,7 @@ final class TestEmptyView: UnitTestCase {
             view: viewController.collectionView,
             options: .test(),
             emptyViewProvider: provider,
-            cellEventCoordinator: nil,
-            didUpdate: nil
+            cellEventCoordinator: nil
         )
 
         XCTAssertTrue(driver.viewModel.isEmpty)
@@ -50,11 +49,11 @@ final class TestEmptyView: UnitTestCase {
         XCTAssertTrue(driver.view.subviews.contains(where: { $0 === emptyView }))
 
         let model = self.fakeCollectionViewModel()
-        driver.viewModel = model
+        driver.update(viewModel: model, animated: false)
         XCTAssertTrue(driver.viewModel.isNotEmpty)
         XCTAssertFalse(driver.view.subviews.contains(where: { $0 === emptyView }))
 
-        driver.viewModel = CollectionViewModel(id: "new_empty")
+        driver.update(viewModel: CollectionViewModel(id: "new_empty"), animated: false)
         XCTAssertTrue(driver.viewModel.isEmpty)
         XCTAssertTrue(driver.view.subviews.contains(where: { $0 === emptyView }))
 

--- a/Tests/Utils/CollectionViewDriverOptions+Extensions.swift
+++ b/Tests/Utils/CollectionViewDriverOptions+Extensions.swift
@@ -16,6 +16,6 @@ import ReactiveCollectionsKit
 
 extension CollectionViewDriverOptions {
     static func test() -> Self {
-        .init(animateUpdates: false, diffOnBackgroundQueue: false, reloadDataOnReplacingViewModel: true)
+        .init(diffOnBackgroundQueue: false, reloadDataOnReplacingViewModel: true)
     }
 }


### PR DESCRIPTION
Reworks how view model updates are handled to make API more ergonomic.

- No longer set the `viewModel` property directly. Instead, must use new `update(viewModel: )` method.

- Pass `didUpdate` and `animated` to this new method. Thus, removing `didUpdate` from `init` and removing `animateUpdates` from `CollectionViewDriverOptions`.

