### PR TITLE
Retain driver weakly in update completion

### DIFF
--- a/Sources/CollectionViewDriver.swift
+++ b/Sources/CollectionViewDriver.swift
@@ -182,9 +182,9 @@ public final class CollectionViewDriver: NSObject {
             from: old,
             to: new,
             animated: animated
-        ) { [unowned self] in
+        ) { [weak self] in
             // UIKit guarantees this closure is called on the main queue.
-            self._displayEmptyViewIfNeeded(animated: animated, completion: completion)
+            self?._displayEmptyViewIfNeeded(animated: animated, completion: completion)
         }
     }
 

--- a/Sources/CollectionViewDriver.swift
+++ b/Sources/CollectionViewDriver.swift
@@ -170,9 +170,9 @@ public final class CollectionViewDriver: NSObject {
         if self.options.reloadDataOnReplacingViewModel {
             // if given a totally new model, simply reload instead of diff
             guard new.id == old.id else {
-                self._dataSource.reload(self.viewModel) { [unowned self] in
-                    // UIKit guarantees this closure is called on the main queue.
-                    self._displayEmptyViewIfNeeded(animated: animated, completion: completion)
+                self._dataSource.reload(self.viewModel) { [weak self] in
+                    // Note: UIKit guarantees this closure is called on the main queue.
+                    self?._displayEmptyViewIfNeeded(animated: animated, completion: completion)
                 }
                 return
             }
@@ -183,7 +183,7 @@ public final class CollectionViewDriver: NSObject {
             to: new,
             animated: animated
         ) { [weak self] in
-            // UIKit guarantees this closure is called on the main queue.
+            // Note: UIKit guarantees this closure is called on the main queue.
             self?._displayEmptyViewIfNeeded(animated: animated, completion: completion)
         }
     }


### PR DESCRIPTION

## Describe your changes

We aren't guaranteed that the driver will be retained by the time the update completes. We should retain weakly to avoid crashes. 
