### PR TITLE
DiffableDataSource: use weak self in _applyDiffSnapshot completion handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ NEXT
 
 - TBA
 
+0.1.6
+-----
+
+- Fixed a crash when hiding a collection view before animations complete. This previously caused a `Fatal error: Attempted to read an unowned reference but the object was already deallocated` crash. ([@lachenmayer](https://github.com/lachenmayer), [#125](https://github.com/jessesquires/ReactiveCollectionsKit/issues/125))
+
 0.1.5
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ NEXT
 0.1.6
 -----
 
-- Fixed a crash when hiding a collection view before animations complete. This previously caused a `Fatal error: Attempted to read an unowned reference but the object was already deallocated` crash. ([@lachenmayer](https://github.com/lachenmayer), [#125](https://github.com/jessesquires/ReactiveCollectionsKit/issues/125))
+- Fixed a potential crash (in `DiffableDataSource`) when hiding a collection view before animations complete when diffing. This may have caused a crash with the message _Fatal error: Attempted to read an unowned reference but the object was already deallocated_. ([@lachenmayer](https://github.com/lachenmayer), [#125](https://github.com/jessesquires/ReactiveCollectionsKit/issues/125), [#126](https://github.com/jessesquires/ReactiveCollectionsKit/issues/126))
 
 0.1.5
 -----

--- a/Sources/DiffableDataSource.swift
+++ b/Sources/DiffableDataSource.swift
@@ -97,7 +97,7 @@ final class DiffableDataSource: UICollectionViewDiffableDataSource<AnyHashable, 
         destinationSnapshot.reconfigureItems(itemsToReconfigure)
 
         // Apply the snapshot with item reconfigure updates.
-        self._applyDiffSnapshot(destinationSnapshot, animated: animated) {
+        self._applyDiffSnapshot(destinationSnapshot, animated: animated) { [weak self] in
 
             // Once the snapshot with item reconfigures is applied,
             // we need to find and apply supplementary view reconfigures, if needed.
@@ -124,7 +124,7 @@ final class DiffableDataSource: UICollectionViewDiffableDataSource<AnyHashable, 
             // (e.g. "My 10 Items")
 
             // Check all the supplementary views and reconfigure them, if needed.
-            self._reconfigureSupplementaryViewsIfNeeded(from: source, to: destination)
+            self?._reconfigureSupplementaryViewsIfNeeded(from: source, to: destination)
 
             // Finally, we're done and can call completion.
             completion?()


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/jessesquires/.github/blob/master/CONTRIBUTING.md)?* 🖤

Closes #125 

## Describe your changes

As discussed in the issue, this fixes a crash with `Fatal error: Attempted to read an unowned reference but the object was already deallocated` when the collection view disappears from the view hierarchy while the animation is still in progress.

Repro: https://github.com/lachenmayer/ReactiveCollectionsKitCrashRepro
Expected behavior: collection view appears & disappears a couple of times, and then the app crashes.

Repro with applied fix: https://github.com/lachenmayer/ReactiveCollectionsKitCrashRepro/tree/apply-fix
Expected behavior: collection view continuous to appear & disappear without a crash.