### PR TITLE
Allow setting a `UICollectionViewDelegateFlowLayout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ NEXT
 0.1.8 - NEXT
 -----
 
-- Allow setting a `UICollectionViewDelegateFlowLayout` object to receive flow layout events from the collection view. ([@jessesquires](https://github.com/jessesquires), [#NNN(https://github.com/jessesquires/ReactiveCollectionsKit/pull/NNN))
+- Allow setting a `UICollectionViewDelegateFlowLayout` object to receive flow layout events from the collection view. ([@jessesquires](https://github.com/jessesquires), [#134](https://github.com/jessesquires/ReactiveCollectionsKit/pull/134))
 
 0.1.7
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ NEXT
 
 - TBA
 
+0.1.8 - NEXT
+-----
+
+- Allow setting a `UICollectionViewDelegateFlowLayout` object to receive flow layout events from the collection view. ([@jessesquires](https://github.com/jessesquires), [#NNN(https://github.com/jessesquires/ReactiveCollectionsKit/pull/NNN))
+
 0.1.7
 -----
 

--- a/Example/Sources/FlowLayout/SimpleFlowLayoutViewController.swift
+++ b/Example/Sources/FlowLayout/SimpleFlowLayoutViewController.swift
@@ -15,22 +15,14 @@ import Foundation
 import ReactiveCollectionsKit
 import UIKit
 
-final class SimpleFlowLayoutViewController: UICollectionViewController {
+final class SimpleFlowLayoutViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
 
     lazy var driver = CollectionViewDriver(view: self.collectionView)
 
     // MARK: Init
 
     init() {
-        /// NOTE: you do not have access to `UICollectionViewDelegateFlowLayout`.
-        /// Docs: https://developer.apple.com/documentation/uikit/uicollectionviewdelegateflowlayout
-        /// You can only create basic flow layouts with fixed item sizes, spacing, etc.
-        /// If you need more flexibility, use `UICollectionViewCompositionalLayout` instead.
         let layout = UICollectionViewFlowLayout()
-        layout.itemSize = CGSize(width: 110, height: 110)
-        layout.minimumInteritemSpacing = 8
-        layout.minimumLineSpacing = 8
-        layout.sectionInset = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         super.init(collectionViewLayout: layout)
         self.collectionView.alwaysBounceVertical = true
     }
@@ -44,6 +36,8 @@ final class SimpleFlowLayoutViewController: UICollectionViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        self.driver.flowLayoutDelegate = self
 
         let models = ColorModel.makeColors()
 
@@ -59,5 +53,40 @@ final class SimpleFlowLayoutViewController: UICollectionViewController {
         let collectionViewModel = CollectionViewModel(id: "static_flow_layout", sections: [section])
 
         self.driver.update(viewModel: collectionViewModel)
+    }
+
+    // MARK: UICollectionViewDelegateFlowLayout
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        let random = Int.random(in: 70...200)
+        return CGSize(width: random, height: random)
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumInteritemSpacingForSectionAt section: Int
+    ) -> CGFloat {
+        8
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumLineSpacingForSectionAt section: Int
+    ) -> CGFloat {
+        8
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        insetForSectionAt section: Int
+    ) -> UIEdgeInsets {
+        UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
     }
 }

--- a/Sources/CollectionViewDriver.swift
+++ b/Sources/CollectionViewDriver.swift
@@ -32,8 +32,11 @@ public final class CollectionViewDriver: NSObject {
     /// The collection view model.
     @Published public private(set) var viewModel: CollectionViewModel
 
-    /// The scroll view delegate to forward.
+    /// A scroll view delegate object to receive forwarded events.
     public weak var scrollViewDelegate: UIScrollViewDelegate?
+
+    /// A flow layout delegate object to receive forwarded events.
+    public weak var flowLayoutDelegate: UICollectionViewDelegateFlowLayout?
 
     private let _emptyViewProvider: EmptyViewProvider?
 
@@ -286,7 +289,7 @@ public final class CollectionViewDriver: NSObject {
     }
 }
 
-// MARK: UICollectionViewDelegate
+// MARK: - UICollectionViewDelegate
 
 extension CollectionViewDriver: UICollectionViewDelegate {
     // MARK: Managing the selected cells
@@ -377,7 +380,7 @@ extension CollectionViewDriver: UICollectionViewDelegate {
     }
 }
 
-// MARK: UIScrollViewDelegate
+// MARK: - UIScrollViewDelegate
 
 extension CollectionViewDriver: UIScrollViewDelegate {
     // MARK: Responding to scrolling and dragging
@@ -467,5 +470,110 @@ extension CollectionViewDriver: UIScrollViewDelegate {
     /// :nodoc:
     public func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
         self.scrollViewDelegate?.scrollViewDidChangeAdjustedContentInset?(scrollView)
+    }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension CollectionViewDriver: UICollectionViewDelegateFlowLayout {
+
+    private var flowLayout: UICollectionViewFlowLayout? {
+        self.view.collectionViewLayout as? UICollectionViewFlowLayout
+    }
+
+    // MARK: Getting the size of items
+
+    /// :nodoc:
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        self.flowLayoutDelegate?.collectionView?(
+            collectionView,
+            layout: collectionViewLayout,
+            sizeForItemAt: indexPath
+        )
+        ?? self.flowLayout?.itemSize
+        ?? .zero
+    }
+
+    // MARK: Getting the section spacing
+
+    /// :nodoc:
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        insetForSectionAt section: Int
+    ) -> UIEdgeInsets {
+        self.flowLayoutDelegate?.collectionView?(
+            collectionView,
+            layout: collectionViewLayout,
+            insetForSectionAt: section
+        )
+        ?? self.flowLayout?.sectionInset
+        ?? .zero
+    }
+
+    /// :nodoc:
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumLineSpacingForSectionAt section: Int
+    ) -> CGFloat {
+        self.flowLayoutDelegate?.collectionView?(
+            collectionView,
+            layout: collectionViewLayout,
+            minimumLineSpacingForSectionAt: section
+        )
+        ?? self.flowLayout?.minimumLineSpacing
+        ?? .zero
+    }
+
+    /// :nodoc:
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumInteritemSpacingForSectionAt section: Int
+    ) -> CGFloat {
+        self.flowLayoutDelegate?.collectionView?(
+            collectionView,
+            layout: collectionViewLayout,
+            minimumInteritemSpacingForSectionAt: section
+        )
+        ?? self.flowLayout?.minimumInteritemSpacing
+        ?? .zero
+    }
+
+    // MARK: Getting the header and footer sizes
+
+    /// :nodoc:
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        referenceSizeForHeaderInSection section: Int
+    ) -> CGSize {
+        self.flowLayoutDelegate?.collectionView?(
+            collectionView,
+            layout: collectionViewLayout,
+            referenceSizeForHeaderInSection: section
+        )
+        ?? self.flowLayout?.headerReferenceSize
+        ?? .zero
+    }
+
+    /// :nodoc:
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        referenceSizeForFooterInSection section: Int
+    ) -> CGSize {
+        self.flowLayoutDelegate?.collectionView?(
+            collectionView,
+            layout: collectionViewLayout,
+            referenceSizeForFooterInSection: section
+        )
+        ?? self.flowLayout?.footerReferenceSize
+        ?? .zero
     }
 }

--- a/Tests/Fakes/FakeFlowLayoutDelegate.swift
+++ b/Tests/Fakes/FakeFlowLayoutDelegate.swift
@@ -1,0 +1,80 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/ReactiveCollectionsKit
+//
+//  GitHub
+//  https://github.com/jessesquires/ReactiveCollectionsKit
+//
+//  Copyright © 2019-present Jesse Squires
+//
+
+import Foundation
+import ReactiveCollectionsKit
+import UIKit
+import XCTest
+
+final class FakeFlowLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
+
+    var expectationSizeForItem: XCTestExpectation?
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        self.expectationSizeForItem?.fulfillAndLog()
+        return .zero
+    }
+
+    var expectationInsetForSection: XCTestExpectation?
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        insetForSectionAt section: Int
+    ) -> UIEdgeInsets {
+        self.expectationInsetForSection?.fulfillAndLog()
+        return .zero
+    }
+
+    var expectationMinimumLineSpacing: XCTestExpectation?
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumLineSpacingForSectionAt section: Int
+    ) -> CGFloat {
+        self.expectationMinimumLineSpacing?.fulfillAndLog()
+        return .zero
+    }
+
+    var expectationMinimumInteritemSpacing: XCTestExpectation?
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        minimumInteritemSpacingForSectionAt section: Int
+    ) -> CGFloat {
+        self.expectationMinimumInteritemSpacing?.fulfillAndLog()
+        return .zero
+    }
+
+    var expectationSizeForHeader: XCTestExpectation?
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        referenceSizeForHeaderInSection section: Int
+    ) -> CGSize {
+        self.expectationSizeForHeader?.fulfillAndLog()
+        return .zero
+    }
+
+    var expectationSizeForFooter: XCTestExpectation?
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        referenceSizeForFooterInSection section: Int
+    ) -> CGSize {
+        self.expectationSizeForFooter?.fulfillAndLog()
+        return .zero
+    }
+}

--- a/Tests/TestFlowLayoutDelegate.swift
+++ b/Tests/TestFlowLayoutDelegate.swift
@@ -1,0 +1,94 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/ReactiveCollectionsKit
+//
+//  GitHub
+//  https://github.com/jessesquires/ReactiveCollectionsKit
+//
+//  Copyright © 2019-present Jesse Squires
+//
+
+import Foundation
+@testable import ReactiveCollectionsKit
+import XCTest
+
+final class TestFlowLayoutDelegate: UnitTestCase, @unchecked Sendable {
+
+    @MainActor
+    func test_forwardsEvents_to_flowLayoutDelegate() {
+        let model = self.fakeCollectionViewModel()
+        let driver = CollectionViewDriver(
+            view: self.collectionView,
+            viewModel: model,
+            options: .test()
+        )
+
+        let flowLayoutDelegate = FakeFlowLayoutDelegate()
+        driver.flowLayoutDelegate = flowLayoutDelegate
+
+        // Setup all expectations
+        flowLayoutDelegate.expectationSizeForItem = self.expectation(name: "size_for_item")
+        flowLayoutDelegate.expectationInsetForSection = self.expectation(name: "inset_for_section")
+        flowLayoutDelegate.expectationMinimumLineSpacing = self.expectation(name: "line_spacing")
+        flowLayoutDelegate.expectationMinimumInteritemSpacing = self.expectation(name: "inter_item_spacing")
+        flowLayoutDelegate.expectationSizeForHeader = self.expectation(name: "size_for_header")
+        flowLayoutDelegate.expectationSizeForFooter = self.expectation(name: "size_for_footer")
+
+        // Call all delegate methods
+        let collectionView = self.collectionView
+        let layout = self.layout
+        let indexPath = IndexPath(item: 0, section: 0)
+
+        _ = driver.collectionView(collectionView, layout: layout, sizeForItemAt: indexPath)
+        _ = driver.collectionView(collectionView, layout: layout, insetForSectionAt: 0)
+        _ = driver.collectionView(collectionView, layout: layout, minimumLineSpacingForSectionAt: 0)
+        _ = driver.collectionView(collectionView, layout: layout, minimumInteritemSpacingForSectionAt: 0)
+        _ = driver.collectionView(collectionView, layout: layout, referenceSizeForHeaderInSection: 0)
+        _ = driver.collectionView(collectionView, layout: layout, referenceSizeForFooterInSection: 0)
+
+        // Verify expectations
+        self.waitForExpectations()
+    }
+
+    @MainActor
+    func test_delegateMethods_returnLayoutProperties_whenNoDelegateIsSet() {
+        let model = self.fakeCollectionViewModel()
+        let driver = CollectionViewDriver(
+            view: self.collectionView,
+            viewModel: model,
+            options: .test()
+        )
+
+        self.layout.itemSize = CGSize(width: 100, height: 100)
+        self.layout.sectionInset = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        self.layout.minimumLineSpacing = 42
+        self.layout.minimumInteritemSpacing = 42
+        self.layout.headerReferenceSize = CGSize(width: 400, height: 200)
+        self.layout.footerReferenceSize = CGSize(width: 400, height: 100)
+
+        let collectionView = self.collectionView
+        let layout = collectionView.collectionViewLayout
+        let indexPath = IndexPath(item: 0, section: 0)
+
+        let size = driver.collectionView(collectionView, layout: layout, sizeForItemAt: indexPath)
+        XCTAssertEqual(size, self.layout.itemSize)
+
+        let inset = driver.collectionView(collectionView, layout: layout, insetForSectionAt: 0)
+        XCTAssertEqual(inset, self.layout.sectionInset)
+
+        let lineSpacing = driver.collectionView(collectionView, layout: layout, minimumLineSpacingForSectionAt: 0)
+        XCTAssertEqual(lineSpacing, self.layout.minimumLineSpacing)
+
+        let itemSpacing = driver.collectionView(collectionView, layout: layout, minimumInteritemSpacingForSectionAt: 0)
+        XCTAssertEqual(itemSpacing, self.layout.minimumInteritemSpacing)
+
+        let headerSize = driver.collectionView(collectionView, layout: layout, referenceSizeForHeaderInSection: 0)
+        XCTAssertEqual(headerSize, self.layout.headerReferenceSize)
+
+        let footerSize = driver.collectionView(collectionView, layout: layout, referenceSizeForFooterInSection: 0)
+        XCTAssertEqual(footerSize, self.layout.footerReferenceSize)
+    }
+}

--- a/Tests/TestScrollViewDelegate.swift
+++ b/Tests/TestScrollViewDelegate.swift
@@ -69,7 +69,5 @@ final class TestScrollViewDelegate: UnitTestCase, @unchecked Sendable {
 
         // Verify expectations
         self.waitForExpectations()
-
-        self.keepDriverAlive(driver)
     }
 }

--- a/Tests/Utils/UnitTestCase.swift
+++ b/Tests/Utils/UnitTestCase.swift
@@ -23,9 +23,11 @@ class UnitTestCase: XCTestCase, @unchecked Sendable {
     @MainActor var collectionView: FakeCollectionView {
         FakeCollectionView(
             frame: Self.frame,
-            collectionViewLayout: FakeCollectionLayout()
+            collectionViewLayout: self.layout
         )
     }
+
+    @MainActor let layout = FakeCollectionLayout()
 
     var keepAliveDrivers = [CollectionViewDriver]()
 


### PR DESCRIPTION
This allows setting a flow layout delegate so that we can forward events to clients. This is very similar to #133.

Note: clients can also (still) configure the layout object directly instead. But, they must choose one or the other — set properties on the layout, or implement the delegate methods.

