### PR TITLE
[Perf] Redesign MainActor isolation + loosen requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ NEXT
 -----
 
 - Allow setting a `UICollectionViewDelegateFlowLayout` object to receive flow layout events from the collection view. ([@jessesquires](https://github.com/jessesquires), [#134](https://github.com/jessesquires/ReactiveCollectionsKit/pull/134))
+- Swift Concurrency improvements: `@MainActor` annotations have been removed from most top-level types and protocols, instead opting to apply `@MainActor` to individual members only where necessary. The goal is to impose fewer restrictions/burdens on clients. ([@jessesquires](https://github.com/jessesquires), [#135](https://github.com/jessesquires/ReactiveCollectionsKit/pull/135))
 
 0.1.7
 -----

--- a/Example/ExampleApp.xcodeproj/project.pbxproj
+++ b/Example/ExampleApp.xcodeproj/project.pbxproj
@@ -57,6 +57,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		0B58E3F92CB72BD0001D4087 /* Exceptions for "Tests" folder in "ExampleAppUITests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				UITests/GridUITests.swift,
+				UITests/ListUITests.swift,
+				UITests/StaticViewUITests.swift,
+			);
+			target = 0B31B95A2BCC62A5006F2078 /* ExampleAppUITests */;
+		};
 		0B8701A52CAE1D980098CB29 /* Exceptions for "Sources" folder in "ExampleApp" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -70,14 +79,6 @@
 				UnitTests/ExampleModelTests.swift,
 			);
 			target = 0B31B9502BCC62A5006F2078 /* ExampleAppTests */;
-		};
-		0B8701B42CAE1D9A0098CB29 /* Exceptions for "Tests" folder in "ExampleAppUITests" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				UITests/GridUITests.swift,
-				UITests/ListUITests.swift,
-			);
-			target = 0B31B95A2BCC62A5006F2078 /* ExampleAppUITests */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -105,7 +106,7 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				0B8701B32CAE1D9A0098CB29 /* Exceptions for "Tests" folder in "ExampleAppTests" target */,
-				0B8701B42CAE1D9A0098CB29 /* Exceptions for "Tests" folder in "ExampleAppUITests" target */,
+				0B58E3F92CB72BD0001D4087 /* Exceptions for "Tests" folder in "ExampleAppUITests" target */,
 			);
 			path = Tests;
 			sourceTree = "<group>";

--- a/Example/Sources/FlowLayout/SimpleFlowLayoutViewController.swift
+++ b/Example/Sources/FlowLayout/SimpleFlowLayoutViewController.swift
@@ -36,6 +36,7 @@ final class SimpleFlowLayoutViewController: UICollectionViewController, UICollec
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.collectionView.accessibilityIdentifier = "Flow Layout"
 
         self.driver.flowLayoutDelegate = self
 

--- a/Example/Sources/Grid/ColorCellViewModelGrid.swift
+++ b/Example/Sources/Grid/ColorCellViewModelGrid.swift
@@ -19,7 +19,7 @@ struct ColorCellViewModelGrid: CellViewModel {
 
     // MARK: CellViewModel
 
-    nonisolated var id: UniqueIdentifier { self.color.id }
+    var id: UniqueIdentifier { self.color.id }
 
     let contextMenuConfiguration: UIContextMenuConfiguration?
 
@@ -30,11 +30,11 @@ struct ColorCellViewModelGrid: CellViewModel {
 
     // MARK: Hashable
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.color)
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.color == right.color
     }
 }

--- a/Example/Sources/Grid/PersonCellViewModelGrid.swift
+++ b/Example/Sources/Grid/PersonCellViewModelGrid.swift
@@ -19,7 +19,7 @@ struct PersonCellViewModelGrid: CellViewModel {
 
     // MARK: CellViewModel
 
-    nonisolated var id: UniqueIdentifier { self.person.id }
+    var id: UniqueIdentifier { self.person.id }
 
     var registration: ViewRegistration {
         ViewRegistration(
@@ -41,12 +41,12 @@ struct PersonCellViewModelGrid: CellViewModel {
 
     // MARK: Hashable
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.person)
         hasher.combine(self.shouldSelect)
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.person == right.person
         && left.shouldSelect == right.shouldSelect
     }

--- a/Example/Sources/List/ColorCellViewModelList.swift
+++ b/Example/Sources/List/ColorCellViewModelList.swift
@@ -19,7 +19,7 @@ struct ColorCellViewModelList: CellViewModel {
 
     // MARK: CellViewModel
 
-    nonisolated var id: UniqueIdentifier { self.color.id }
+    var id: UniqueIdentifier { self.color.id }
 
     let contextMenuConfiguration: UIContextMenuConfiguration?
 
@@ -49,11 +49,11 @@ struct ColorCellViewModelList: CellViewModel {
 
     // MARK: Hashable
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.color)
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.color == right.color
     }
 }

--- a/Example/Sources/List/PersonCellViewModelList.swift
+++ b/Example/Sources/List/PersonCellViewModelList.swift
@@ -19,7 +19,7 @@ struct PersonCellViewModelList: CellViewModel {
 
     // MARK: CellViewModel
 
-    nonisolated var id: UniqueIdentifier { self.person.id }
+    var id: UniqueIdentifier { self.person.id }
 
     let contextMenuConfiguration: UIContextMenuConfiguration?
 
@@ -56,11 +56,11 @@ struct PersonCellViewModelList: CellViewModel {
 
     // MARK: Hashable
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.person)
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.person == right.person
     }
 }

--- a/Example/Sources/SimpleStatic/SimpleStaticViewController.swift
+++ b/Example/Sources/SimpleStatic/SimpleStaticViewController.swift
@@ -37,6 +37,7 @@ final class SimpleStaticViewController: UICollectionViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.collectionView.accessibilityIdentifier = "Simple Static"
 
         let models = ColorModel.makeColors()
 

--- a/Example/Sources/SupplementaryViews/FooterView.swift
+++ b/Example/Sources/SupplementaryViews/FooterView.swift
@@ -19,7 +19,7 @@ struct FooterViewModel: SupplementaryFooterViewModel {
 
     // MARK: SupplementaryViewModel
 
-    nonisolated var id: UniqueIdentifier { self.text }
+    var id: UniqueIdentifier { self.text }
 
     func configure(view: UICollectionViewListCell) {
         var config = UIListContentConfiguration.groupedFooter()

--- a/Example/Sources/SupplementaryViews/HeaderView.swift
+++ b/Example/Sources/SupplementaryViews/HeaderView.swift
@@ -25,7 +25,7 @@ struct HeaderViewModel: SupplementaryHeaderViewModel {
 
     // MARK: SupplementaryViewModel
 
-    nonisolated var id: UniqueIdentifier { self.title }
+    var id: UniqueIdentifier { self.title }
 
     func configure(view: UICollectionViewListCell) {
         var config: UIListContentConfiguration

--- a/Example/Tests/UITests/StaticViewUITests.swift
+++ b/Example/Tests/UITests/StaticViewUITests.swift
@@ -1,0 +1,39 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/ReactiveCollectionsKit
+//
+//  GitHub
+//  https://github.com/jessesquires/ReactiveCollectionsKit
+//
+//  Copyright © 2019-present Jesse Squires
+//
+
+import XCTest
+
+final class StaticViewUITests: XCTestCase, @unchecked Sendable {
+    @MainActor var app: XCUIApplication { XCUIApplication() }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        self.continueAfterFailure = false
+        await self.app.launch()
+    }
+
+    @MainActor
+    func test_view_other_tabs() {
+        self.app.activate()
+        XCTAssertTrue(true)
+
+        self.app.tabBars["Tab Bar"].buttons["Simple Static"].tap()
+        self.app.collectionViews["Simple Static"].swipeUp()
+        self.app.collectionViews["Simple Static"].swipeDown()
+
+        self.app.tabBars["Tab Bar"].buttons["Flow Layout"].tap()
+        self.app.collectionViews["Flow Layout"].swipeUp()
+        self.app.collectionViews["Flow Layout"].swipeDown()
+
+    }
+}

--- a/Sources/CollectionViewConstants.swift
+++ b/Sources/CollectionViewConstants.swift
@@ -1,0 +1,31 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/ReactiveCollectionsKit
+//
+//  GitHub
+//  https://github.com/jessesquires/ReactiveCollectionsKit
+//
+//  Copyright © 2019-present Jesse Squires
+//
+
+import Foundation
+import UIKit
+
+/// HACK: unfortunately, these `UICollectionView` constants are marked as `@MainActor`.
+///
+/// They do not need to be `@MainActor` and do no introduce any race conditions.
+/// So, we're using the raw string values instead.
+enum CollectionViewConstants {
+    /// The same value as `UICollectionView.elementKindSectionHeader`.
+    static var headerKind: SupplementaryViewKind {
+        "UICollectionElementKindSectionHeader"
+    }
+
+    /// The same value as `UICollectionView.elementKindSectionFooter`.
+    static var footerKind: SupplementaryViewKind {
+        "UICollectionElementKindSectionFooter"
+    }
+}

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -15,7 +15,6 @@ import Foundation
 import UIKit
 
 /// Represents a collection view with sections and items.
-@MainActor
 public struct CollectionViewModel: Hashable, DiffableViewModel {
     /// Returns the empty collection view model.
     public static var empty: Self {
@@ -252,53 +251,39 @@ public struct CollectionViewModel: Hashable, DiffableViewModel {
 
 extension CollectionViewModel: Collection, RandomAccessCollection {
     /// :nodoc:
-    nonisolated public var count: Int {
-        MainActor.assumeIsolated {
-            self.sections.count
-        }
+    public var count: Int {
+        self.sections.count
     }
 
     /// :nodoc:
-    nonisolated public var isEmpty: Bool {
-        MainActor.assumeIsolated {
-            self.sections.isEmpty
-        }
+    public var isEmpty: Bool {
+        self.sections.isEmpty
     }
 
     /// :nodoc:
-    nonisolated public var startIndex: Int {
-        MainActor.assumeIsolated {
-            self.sections.startIndex
-        }
+    public var startIndex: Int {
+        self.sections.startIndex
     }
 
     /// :nodoc:
-    nonisolated public var endIndex: Int {
-        MainActor.assumeIsolated {
-            self.sections.endIndex
-        }
+    public var endIndex: Int {
+        self.sections.endIndex
     }
 
     /// :nodoc:
-    nonisolated public subscript(position: Int) -> SectionViewModel {
-        MainActor.assumeIsolated {
-            self.sections[position]
-        }
+    public subscript(position: Int) -> SectionViewModel {
+        self.sections[position]
     }
 
     /// :nodoc:
-    nonisolated public func index(after pos: Int) -> Int {
-        MainActor.assumeIsolated {
-            self.sections.index(after: pos)
-        }
+    public func index(after pos: Int) -> Int {
+        self.sections.index(after: pos)
     }
 }
 
 extension CollectionViewModel: CustomDebugStringConvertible {
     /// :nodoc:
-    nonisolated public var debugDescription: String {
-        MainActor.assumeIsolated {
-            collectionDebugDescription(self)
-        }
+    public var debugDescription: String {
+        collectionDebugDescription(self)
     }
 }

--- a/Sources/DebugDescriptions.swift
+++ b/Sources/DebugDescriptions.swift
@@ -129,7 +129,6 @@ private func debugDescriptionBuilder<Target: TextOutputStream>(
     }
 }
 
-@MainActor
 func collectionDebugDescription(_ collection: CollectionViewModel) -> String {
     var output = ""
     debugDescriptionBuilder(
@@ -146,7 +145,6 @@ func collectionDebugDescription(_ collection: CollectionViewModel) -> String {
     return output
 }
 
-@MainActor
 func sectionDebugDescription(_ section: SectionViewModel) -> String {
     var output = ""
     debugDescriptionBuilder(

--- a/Sources/DiffableViewModel.swift
+++ b/Sources/DiffableViewModel.swift
@@ -17,7 +17,6 @@ import Foundation
 public typealias UniqueIdentifier = AnyHashable
 
 /// Describes a view model that is uniquely identifiable and diffable.
-@MainActor
 public protocol DiffableViewModel: Identifiable, Hashable {
     /// An identifier that uniquely identifies this instance.
     var id: UniqueIdentifier { get }

--- a/Sources/SectionViewModel.swift
+++ b/Sources/SectionViewModel.swift
@@ -14,7 +14,6 @@
 import Foundation
 
 /// Represents a section of items in a collection.
-@MainActor
 public struct SectionViewModel: DiffableViewModel {
     // MARK: DiffableViewModel
 
@@ -194,9 +193,9 @@ public struct SectionViewModel: DiffableViewModel {
         anyFooter: AnySupplementaryViewModel?,
         anySupplementaryViews: [AnySupplementaryViewModel]
     ) {
-        if let anyHeader { precondition(anyHeader._isHeader) }
-        if let anyFooter { precondition(anyFooter._isFooter) }
-        precondition(anySupplementaryViews.allSatisfy { !$0._isHeader && !$0._isFooter })
+        if let anyHeader { precondition(anyHeader.isHeader) }
+        if let anyFooter { precondition(anyFooter.isFooter) }
+        precondition(anySupplementaryViews.allSatisfy(\.isOtherSupplementaryView))
         self.id = id
         self.cells = anyCells
         self.header = anyHeader
@@ -253,53 +252,39 @@ public struct SectionViewModel: DiffableViewModel {
 
 extension SectionViewModel: Collection, RandomAccessCollection {
     /// :nodoc:
-    nonisolated public var count: Int {
-        MainActor.assumeIsolated {
-            self.cells.count
-        }
+    public var count: Int {
+        self.cells.count
     }
 
     /// :nodoc:
-    nonisolated public var isEmpty: Bool {
-        MainActor.assumeIsolated {
-            self.cells.isEmpty
-        }
+    public var isEmpty: Bool {
+        self.cells.isEmpty
     }
 
     /// :nodoc:
-    nonisolated public var startIndex: Int {
-        MainActor.assumeIsolated {
-            self.cells.startIndex
-        }
+    public var startIndex: Int {
+        self.cells.startIndex
     }
 
     /// :nodoc:
-    nonisolated public var endIndex: Int {
-        MainActor.assumeIsolated {
-            self.cells.endIndex
-        }
+    public var endIndex: Int {
+        self.cells.endIndex
     }
 
     /// :nodoc:
-    nonisolated public subscript(position: Int) -> AnyCellViewModel {
-        MainActor.assumeIsolated {
-            self.cells[position]
-        }
+    public subscript(position: Int) -> AnyCellViewModel {
+        self.cells[position]
     }
 
     /// :nodoc:
-    nonisolated public func index(after pos: Int) -> Int {
-        MainActor.assumeIsolated {
-            self.cells.index(after: pos)
-        }
+    public func index(after pos: Int) -> Int {
+        self.cells.index(after: pos)
     }
 }
 
 extension SectionViewModel: CustomDebugStringConvertible {
     /// :nodoc:
-    nonisolated public var debugDescription: String {
-        MainActor.assumeIsolated {
-            sectionDebugDescription(self)
-        }
+    public var debugDescription: String {
+        sectionDebugDescription(self)
     }
 }

--- a/Sources/SupplementaryFooterViewModel.swift
+++ b/Sources/SupplementaryFooterViewModel.swift
@@ -16,7 +16,6 @@ import UIKit
 
 /// Defines a view model that describes and configures a footer view
 /// for a section in the collection view.
-@MainActor
 public protocol SupplementaryFooterViewModel: SupplementaryViewModel {
     /// The collection view footer element kind.
     static var kind: SupplementaryViewKind { get }
@@ -25,7 +24,7 @@ public protocol SupplementaryFooterViewModel: SupplementaryViewModel {
 extension SupplementaryFooterViewModel {
     /// Default implementation. Returns a section footer kind.
     public static var kind: SupplementaryViewKind {
-        UICollectionView.elementKindSectionFooter
+        CollectionViewConstants.footerKind
     }
 
     /// A default registration for this footer view model for class-based views.

--- a/Sources/SupplementaryHeaderViewModel.swift
+++ b/Sources/SupplementaryHeaderViewModel.swift
@@ -16,7 +16,6 @@ import UIKit
 
 /// Defines a view model that describes and configures a header view
 /// for a section in the collection view.
-@MainActor
 public protocol SupplementaryHeaderViewModel: SupplementaryViewModel {
     /// The collection view header element kind.
     static var kind: SupplementaryViewKind { get }
@@ -25,8 +24,9 @@ public protocol SupplementaryHeaderViewModel: SupplementaryViewModel {
 extension SupplementaryHeaderViewModel {
     /// Default implementation. Returns a section header kind.
     public static var kind: SupplementaryViewKind {
-        UICollectionView.elementKindSectionHeader
+        CollectionViewConstants.headerKind
     }
+
     /// A default registration for this header view model for class-based views.
     ///
     /// - Warning: Does not work for nib-based views.

--- a/Sources/ViewRegistration.swift
+++ b/Sources/ViewRegistration.swift
@@ -15,8 +15,7 @@ import Foundation
 import UIKit
 
 /// Describes all information needed to register a view for reuse with a `UICollectionView`.
-@MainActor
-public struct ViewRegistration: Hashable {
+public struct ViewRegistration: Hashable, Sendable {
     /// The view reuse identifier.
     public let reuseIdentifier: String
 
@@ -44,6 +43,7 @@ public struct ViewRegistration: Hashable {
 
     // MARK: Dequeuing Views
 
+    @MainActor
     func dequeueViewFor(collectionView: UICollectionView, at indexPath: IndexPath) -> UICollectionReusableView {
         switch self.viewType {
         case .cell:
@@ -54,10 +54,12 @@ public struct ViewRegistration: Hashable {
         }
     }
 
+    @MainActor
     private func _dequeueCellFor(collectionView: UICollectionView, at indexPath: IndexPath) -> UICollectionViewCell {
         collectionView.dequeueReusableCell(withReuseIdentifier: self.reuseIdentifier, for: indexPath)
     }
 
+    @MainActor
     private func _dequeueSupplementaryViewFor(kind: String, collectionView: UICollectionView, at indexPath: IndexPath) -> UICollectionReusableView {
         collectionView.dequeueReusableSupplementaryView(
             ofKind: kind,
@@ -68,6 +70,7 @@ public struct ViewRegistration: Hashable {
 
     // MARK: Registering Views
 
+    @MainActor
     func registerWith(collectionView: UICollectionView) {
         switch self.viewType {
         case .cell:
@@ -78,6 +81,7 @@ public struct ViewRegistration: Hashable {
         }
     }
 
+    @MainActor
     private func _registerCellWith(collectionView: UICollectionView) {
         switch self.method {
         case .viewClass(let anyClass):
@@ -89,6 +93,7 @@ public struct ViewRegistration: Hashable {
         }
     }
 
+    @MainActor
     private func _registerSupplementaryView(kind: String, with collectionView: UICollectionView) {
         switch self.method {
         case .viewClass(let anyClass):

--- a/Sources/ViewRegistrationProvider.swift
+++ b/Sources/ViewRegistrationProvider.swift
@@ -15,7 +15,6 @@ import Foundation
 import UIKit
 
 /// Provides registration information for a reusable view in a `UICollectionView`.
-@MainActor
 public protocol ViewRegistrationProvider {
     /// The view registration information.
     var registration: ViewRegistration { get }

--- a/Sources/ViewRegistrationViewType.swift
+++ b/Sources/ViewRegistrationViewType.swift
@@ -43,4 +43,12 @@ public enum ViewRegistrationViewType: Hashable, Sendable {
         case .supplementary: true
         }
     }
+
+    var isHeader: Bool {
+        self.kind == CollectionViewConstants.headerKind
+    }
+
+    var isFooter: Bool {
+        self.kind == CollectionViewConstants.footerKind
+    }
 }

--- a/Tests/Fakes/FakeCellNibView.swift
+++ b/Tests/Fakes/FakeCellNibView.swift
@@ -69,11 +69,11 @@ struct FakeCellNibViewModel: CellViewModel {
         self.expectationDidUnhighlight?.fulfillAndLog()
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.id == right.id
     }
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.id)
     }
 }

--- a/Tests/Fakes/FakeNumberModel.swift
+++ b/Tests/Fakes/FakeNumberModel.swift
@@ -28,7 +28,7 @@ struct FakeNumberModel: Hashable {
 struct FakeNumberCellViewModel: CellViewModel {
     let model: FakeNumberModel
 
-    nonisolated var id: UniqueIdentifier {
+    var id: UniqueIdentifier {
         self.model.id
     }
 
@@ -89,11 +89,11 @@ struct FakeNumberCellViewModel: CellViewModel {
         self.contextMenuConfiguration = contextMenuConfiguration
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.model == right.model
     }
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.model)
     }
 }

--- a/Tests/Fakes/FakeSupplementaryNibView.swift
+++ b/Tests/Fakes/FakeSupplementaryNibView.swift
@@ -41,11 +41,11 @@ struct FakeSupplementaryNibViewModel: SupplementaryViewModel {
         self.expectationConfigureView?.fulfillAndLog()
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.id == right.id
     }
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.id)
     }
 }

--- a/Tests/Fakes/FakeSupplementaryViewModel.swift
+++ b/Tests/Fakes/FakeSupplementaryViewModel.swift
@@ -20,7 +20,7 @@ struct FakeSupplementaryViewModel: SupplementaryViewModel {
 
     let title: String
 
-    nonisolated var id: UniqueIdentifier { self.title }
+    var id: UniqueIdentifier { self.title }
 
     var registration: ViewRegistration {
         ViewRegistration(
@@ -49,11 +49,11 @@ struct FakeSupplementaryViewModel: SupplementaryViewModel {
         self.title = title
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.title == right.title
     }
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.title)
     }
 }
@@ -63,7 +63,7 @@ final class FakeSupplementaryView: UICollectionViewCell { }
 struct FakeHeaderViewModel: SupplementaryHeaderViewModel {
     let title: String
 
-    nonisolated var id: UniqueIdentifier { "Header" }
+    var id: UniqueIdentifier { "Header" }
 
     var expectationConfigureView: XCTestExpectation?
     func configure(view: FakeCollectionHeaderView) {
@@ -84,11 +84,11 @@ struct FakeHeaderViewModel: SupplementaryHeaderViewModel {
         self.title = title
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.title == right.title
     }
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.title)
     }
 }
@@ -98,7 +98,7 @@ final class FakeCollectionHeaderView: UICollectionReusableView { }
 struct FakeFooterViewModel: SupplementaryFooterViewModel {
     let title: String
 
-    nonisolated var id: UniqueIdentifier { "Footer" }
+    var id: UniqueIdentifier { "Footer" }
 
     var expectationConfigureView: XCTestExpectation?
     func configure(view: FakeCollectionFooterView) {
@@ -119,11 +119,11 @@ struct FakeFooterViewModel: SupplementaryFooterViewModel {
         self.title = title
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.title == right.title
     }
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.title)
     }
 }

--- a/Tests/Fakes/FakeTextModel.swift
+++ b/Tests/Fakes/FakeTextModel.swift
@@ -27,7 +27,7 @@ struct FakeTextModel: Hashable {
 struct FakeTextCellViewModel: CellViewModel {
     let model: FakeTextModel
 
-    nonisolated var id: UniqueIdentifier {
+    var id: UniqueIdentifier {
         self.model.text
     }
 
@@ -88,11 +88,11 @@ struct FakeTextCellViewModel: CellViewModel {
         self.contextMenuConfiguration = contextMenuConfiguration
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.model == right.model
     }
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.model)
     }
 }

--- a/Tests/TestCollectionExtensions.swift
+++ b/Tests/TestCollectionExtensions.swift
@@ -16,6 +16,7 @@ import Foundation
 import XCTest
 
 final class TestCollectionExtensions: XCTestCase {
+
     func test_isNotEmpty() {
         XCTAssertTrue([1, 2, 3].isNotEmpty)
         XCTAssertFalse([].isNotEmpty)

--- a/Tests/TestCollectionViewConstants.swift
+++ b/Tests/TestCollectionViewConstants.swift
@@ -1,0 +1,30 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/ReactiveCollectionsKit
+//
+//  GitHub
+//  https://github.com/jessesquires/ReactiveCollectionsKit
+//
+//  Copyright © 2019-present Jesse Squires
+//
+
+import Foundation
+@testable import ReactiveCollectionsKit
+import UIKit
+import XCTest
+
+final class TestCollectionViewConstants: XCTestCase {
+
+    @MainActor
+    func test_header() {
+        XCTAssertEqual(CollectionViewConstants.headerKind, UICollectionView.elementKindSectionHeader)
+    }
+
+    @MainActor
+    func test_footer() {
+        XCTAssertEqual(CollectionViewConstants.footerKind, UICollectionView.elementKindSectionFooter)
+    }
+}

--- a/Tests/TestCollectionViewDriverReconfigure.swift
+++ b/Tests/TestCollectionViewDriverReconfigure.swift
@@ -96,11 +96,11 @@ private struct MyStaticCellViewModel: CellViewModel {
         expectation?.fulfillAndLog()
     }
 
-    nonisolated static func == (left: Self, right: Self) -> Bool {
+    static func == (left: Self, right: Self) -> Bool {
         left.name == right.name
     }
 
-    nonisolated func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(self.name)
     }
 }

--- a/Tests/TestViewRegistrationViewType.swift
+++ b/Tests/TestViewRegistrationViewType.swift
@@ -28,16 +28,41 @@ final class TestViewRegistrationViewType: XCTestCase {
     func test_isCell() {
         let cell = ViewRegistrationViewType.cell
         XCTAssertTrue(cell.isCell)
+        XCTAssertFalse(cell.isSupplementary)
+        XCTAssertFalse(cell.isHeader)
+        XCTAssertFalse(cell.isFooter)
 
         let view = ViewRegistrationViewType.supplementary(kind: "kind")
         XCTAssertFalse(view.isCell)
     }
 
     func test_isSupplementary() {
-        let cell = ViewRegistrationViewType.cell
-        XCTAssertFalse(cell.isSupplementary)
-
         let view = ViewRegistrationViewType.supplementary(kind: "kind")
         XCTAssertTrue(view.isSupplementary)
+        XCTAssertFalse(view.isHeader)
+        XCTAssertFalse(view.isFooter)
+        XCTAssertFalse(view.isCell)
+
+        let cell = ViewRegistrationViewType.cell
+        XCTAssertFalse(cell.isSupplementary)
+    }
+
+    func test_isHeader() {
+        let view = ViewRegistrationViewType.supplementary(kind: CollectionViewConstants.headerKind)
+
+        XCTAssertTrue(view.isHeader)
+        XCTAssertTrue(view.isSupplementary)
+
+        XCTAssertFalse(view.isFooter)
+        XCTAssertFalse(view.isCell)
+    }
+
+    func test_isFooter() {
+        let view = ViewRegistrationViewType.supplementary(kind: CollectionViewConstants.footerKind)
+        XCTAssertTrue(view.isFooter)
+        XCTAssertTrue(view.isSupplementary)
+
+        XCTAssertFalse(view.isHeader)
+        XCTAssertFalse(view.isCell)
     }
 }


### PR DESCRIPTION
This audits and reworks all usage of `@MainActor`.

This removes `@MainActor` from most types and protocols, instead opting to apply `@MainActor` to individual members only where necessary.

The motivation here is two-fold:

1. Impose fewer burdens on clients by not mandating entire types be annotated as `@MainActor`.

2. Enable upcoming performance improvements by doing more diffing work on a background thread.

