### PR TITLE
[Perf] avoid unnecessary copies of cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NEXT
 
 - Allow setting a `UICollectionViewDelegateFlowLayout` object to receive flow layout events from the collection view. ([@jessesquires](https://github.com/jessesquires), [#134](https://github.com/jessesquires/ReactiveCollectionsKit/pull/134))
 - Swift Concurrency improvements: `@MainActor` annotations have been removed from most top-level types and protocols, instead opting to apply `@MainActor` to individual members only where necessary. The goal is to impose fewer restrictions/burdens on clients. ([@jessesquires](https://github.com/jessesquires), [#135](https://github.com/jessesquires/ReactiveCollectionsKit/pull/135))
+- Various performance improvements. ([@jessesquires](https://github.com/jessesquires), [#136](https://github.com/jessesquires/ReactiveCollectionsKit/pull/136))
 
 0.1.7
 -----

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -70,7 +70,12 @@ public struct CollectionViewModel: Hashable, DiffableViewModel {
     /// - Parameter id: The identifier for the cell.
     /// - Returns: The cell, if it exists.
     public func cellViewModel(for id: UniqueIdentifier) -> AnyCellViewModel? {
-        self.flatMap(\.cells).first { $0.id == id }
+        for section in self.sections {
+            for cell in section.cells where cell.id == id {
+                return cell
+            }
+        }
+        return nil
     }
 
     /// Returns the cell at the specified index path.
@@ -96,7 +101,12 @@ public struct CollectionViewModel: Hashable, DiffableViewModel {
     /// - Parameter id: The identifier for the supplementary view.
     /// - Returns: The supplementary view, if it exists.
     public func supplementaryViewModel(for id: UniqueIdentifier) -> AnySupplementaryViewModel? {
-        self.flatMap(\.supplementaryViews).first { $0.id == id }
+        for section in self.sections {
+            for view in section.supplementaryViews where view.id == id {
+                return view
+            }
+        }
+        return nil
     }
 
     /// Returns the supplementary view for the specified kind and index path.

--- a/Sources/DiffableSnapshot.swift
+++ b/Sources/DiffableSnapshot.swift
@@ -21,12 +21,12 @@ extension DiffableSnapshot {
     init(viewModel: CollectionViewModel) {
         self.init()
 
-        let allSectionIdentifiers = viewModel.sections.map(\.id)
-        self.appendSections(allSectionIdentifiers)
+        for section in viewModel.sections {
+            self.appendSections([section.id])
 
-        viewModel.sections.forEach {
-            let allCellIdentifiers = $0.cells.map(\.id)
-            self.appendItems(allCellIdentifiers, toSection: $0.id)
+            for cell in section {
+                self.appendItems([cell.id], toSection: section.id)
+            }
         }
     }
 }


### PR DESCRIPTION
For very large collections, these functions can be a bottleneck for performance, causing frequent, unnecessary copies of cells and supplementary views.

