### PR TITLE
Add horizontal scrolling example to Example app

### DIFF
--- a/Example/Sources/Grid/GridViewController.swift
+++ b/Example/Sources/Grid/GridViewController.swift
@@ -76,7 +76,6 @@ final class GridViewController: ExampleViewController, CellEventCoordinator {
     // MARK: Private
 
     private static func makeLayout() -> UICollectionViewCompositionalLayout {
-        let fractionalWidth = CGFloat(0.5)
         let inset = CGFloat(4)
 
         // Supplementary Item
@@ -89,15 +88,17 @@ final class GridViewController: ExampleViewController, CellEventCoordinator {
                                                         containerAnchor: badgeAnchor)
 
         // Item
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(fractionalWidth),
-                                              heightDimension: .fractionalHeight(1))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize, supplementaryItems: [badge])
         item.contentInsets = NSDirectionalEdgeInsets(top: inset, leading: inset, bottom: inset, trailing: inset)
 
         // Group
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                               heightDimension: .fractionalWidth(fractionalWidth))
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5),
+                                               heightDimension: .fractionalHeight(0.5))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize,
+                                                     subitem: item,
+                                                     count: 2)
 
         // Headers and Footers
         let headerFooterSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
@@ -113,6 +114,7 @@ final class GridViewController: ExampleViewController, CellEventCoordinator {
 
         // Section
         let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
         section.contentInsets = NSDirectionalEdgeInsets(top: inset, leading: inset, bottom: inset, trailing: inset)
         section.boundarySupplementaryItems = [sectionHeader, sectionFooter]
 


### PR DESCRIPTION
Related to Issue #101 

## Describe your changes

As a newcomer to the library, I figured a good way to get my feet wet would be to try to add something to the Example app. As mentioned in the issue, we're looking for several new examples, including a horizontal section, so that's what I tried to do here. 

To enable this, I essentially followed the example set by the Colors and People sections and added a new `PlanetModel`. Then, I added a horizontally scrolling section to the Grid tab's comp layout logic to display the 8 planets, as well as the accompanying cell view model mapping.

At the end, I renamed the `GridColorCell` to `BasicGridCell` as a way to just reuse the existing cell for both sections, but happy to just create a separate cell if that's preferred. Also, I'm not sure if the tab is best described as `Grid` now that there's a non-grid section - let me know if we're prefer to rename that, have a new tab, etc.

One other tweak I made was to have the supplementary views not follow the content insets of the section. This is super minor (happy to delete if we'd like), but I noticed that there was a tiny gap between the edge of the section headers and the edge of the screen, so this would address that. It's hard to show in a screenshot, but can be seen by looking closely in the sim.

## Concerns
These are pre-existing things so I didn't investigate them much further, but I'm happy to create Issues for them to discuss them further.

1. I'm noticing that shuffling the collection slowly/eventually resets the scroll offset to 0. If you scroll down to the bottom then shuffle a bunch of times, you'll eventually be back at the top.
2. When the app first loads, there's a slight flicker of the empty state as well as the Colors section/section header.

## Demo

https://github.com/user-attachments/assets/cfb235cf-dee6-42bc-b13b-400c00fc0068