### PR TITLE
fix: avoid preload viewDidLoad

### DIFF
--- a/Example/Sources/FlowLayout/SimpleFlowLayoutViewController.swift
+++ b/Example/Sources/FlowLayout/SimpleFlowLayoutViewController.swift
@@ -24,7 +24,6 @@ final class SimpleFlowLayoutViewController: UICollectionViewController, UICollec
     init() {
         let layout = UICollectionViewFlowLayout()
         super.init(collectionViewLayout: layout)
-        self.collectionView.alwaysBounceVertical = true
     }
 
     @available(*, unavailable)
@@ -36,6 +35,7 @@ final class SimpleFlowLayoutViewController: UICollectionViewController, UICollec
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.collectionView.alwaysBounceVertical = true
         self.collectionView.accessibilityIdentifier = "Flow Layout"
 
         self.driver.flowLayoutDelegate = self


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/jessesquires/.github/blob/master/CONTRIBUTING.md)?*

Issue #141 

## Describe your changes

*Clearly and concisely describe what's in this pull request. Include screenshots, if necessary.*

1. Avoid access `collectionView` in `init` (`SimpleFlowLayoutViewController`), which will call `viewDidLoad` immediatly.
