### PR TITLE
Support item expanding and collapsing

### DIFF
--- a/Example/Sources/List/ListViewController.swift
+++ b/Example/Sources/List/ListViewController.swift
@@ -81,9 +81,9 @@ final class ListViewController: ExampleViewController, CellEventCoordinator {
 
     private func makeViewModel() -> CollectionViewModel {
         // Create People Section
-        let peopleCellViewModels = self.model.people.map {
+        let peopleCellViewModels = self.model.people.enumerated().map { index, person in
             let menuConfig = UIContextMenuConfiguration.configFor(
-                itemId: $0.id,
+                itemId: person.id,
                 favoriteAction: { [unowned self] in
                     self.toggleFavorite(id: $0)
                 },
@@ -92,9 +92,12 @@ final class ListViewController: ExampleViewController, CellEventCoordinator {
                 }
             )
 
+            let children = makeViewModel(for: person.subPeople)
+
             return PersonCellViewModelList(
-                person: $0,
-                contextMenuConfiguration: menuConfig
+                person: person,
+                contextMenuConfiguration: menuConfig,
+                children: children
             ).eraseToAnyViewModel()
         }
         let peopleHeader = HeaderViewModel(title: "People", style: .small)
@@ -133,6 +136,16 @@ final class ListViewController: ExampleViewController, CellEventCoordinator {
 
         // Create final view model
         return CollectionViewModel(id: "list_view", sections: [peopleSection, colorSection])
+    }
+
+    private func makeViewModel(for people: [PersonModel]) -> [AnyCellViewModel] {
+        let children: [AnyCellViewModel] = people.map {
+            PersonCellViewModelList(person: $0,
+                                    contextMenuConfiguration: nil,
+                                    children: makeViewModel(for: $0.subPeople)).eraseToAnyViewModel()
+        }
+
+        return children
     }
 }
 

--- a/Example/Sources/List/PersonCellViewModelList.swift
+++ b/Example/Sources/List/PersonCellViewModelList.swift
@@ -23,6 +23,8 @@ struct PersonCellViewModelList: CellViewModel {
 
     let contextMenuConfiguration: UIContextMenuConfiguration?
 
+    let children: [AnyCellViewModel]
+
     func configure(cell: UICollectionViewListCell) {
         var contentConfiguration = UIListContentConfiguration.subtitleCell()
         contentConfiguration.text = self.person.name
@@ -35,7 +37,7 @@ struct PersonCellViewModelList: CellViewModel {
         let flagEmoji = UICellAccessory.customView(
             configuration: .init(customView: label, placement: .leading())
         )
-        var accessories = [flagEmoji, .disclosureIndicator()]
+        var accessories = [flagEmoji, .disclosureIndicator(), .outlineDisclosure()]
 
         if self.person.isFavorite {
             let imageView = UIImageView(image: UIImage(systemName: "star.fill"))

--- a/Example/Sources/PersonModel/PersonModel.swift
+++ b/Example/Sources/PersonModel/PersonModel.swift
@@ -19,6 +19,7 @@ struct PersonModel: Hashable {
     let birthdate: Date
     let nationality: String
     var isFavorite = false
+    var subPeople: [PersonModel] = []
 
     var birthDateText: String {
         self.birthdate.formatted(date: .long, time: .omitted)
@@ -45,7 +46,13 @@ extension Date {
 extension PersonModel {
     static func makePeople() -> [PersonModel] {
         [
-            PersonModel(name: "Noam Chomsky", birthdate: Date(year: 1_928, month: 12, day: 7), nationality: "🇺🇸"),
+            PersonModel(name: "Noam Chomsky", birthdate: Date(year: 1_928, month: 12, day: 7), nationality: "🇺🇸", subPeople: [
+                .init(name: "Steve Jobs", birthdate: Date(year: 1955, month: 2, day: 24), nationality: "🇺🇸", subPeople: [
+                    .init(name: "Another Steve Jobs", birthdate: Date(year: 1955, month: 2, day: 24), nationality: "🇺🇸", subPeople: [
+                        .init(name: "Yet Another Steve Jobs", birthdate: Date(year: 1955, month: 2, day: 24), nationality: "🇺🇸")
+                    ])
+                ])
+            ]),
             PersonModel(name: "Emma Goldman", birthdate: Date(year: 1_869, month: 6, day: 27), nationality: "🇷🇺"),
             PersonModel(name: "Mikhail Bakunin", birthdate: Date(year: 1_814, month: 5, day: 30), nationality: "🇷🇺"),
             PersonModel(name: "Ursula K. Le Guin", birthdate: Date(year: 1_929, month: 10, day: 21), nationality: "🇺🇸"),

--- a/Sources/CellViewModel.swift
+++ b/Sources/CellViewModel.swift
@@ -38,6 +38,10 @@ public protocol CellViewModel: DiffableViewModel, ViewRegistrationProvider {
     /// This corresponds to the delegate method `collectionView(_:contextMenuConfigurationForItemAt:point:)`.
     var contextMenuConfiguration: UIContextMenuConfiguration? { get }
 
+    /// Returns an array of children for the cell.
+    /// These children correspond to the items that have been appended to this item as part of a `NSDiffableDataSourceSectionSnapshot`.
+    var children: [AnyCellViewModel] { get }
+
     /// Configures the provided cell for display in the collection.
     /// - Parameter cell: The cell to configure.
     @MainActor
@@ -89,6 +93,9 @@ extension CellViewModel {
 
     /// Default implementation. Returns `true`.
     public var shouldHighlight: Bool { true }
+
+    /// Default implementation. Returns `[]`.
+    public var children: [AnyCellViewModel] { [] }
 
     /// Default implementation. Returns `nil`.
     public var contextMenuConfiguration: UIContextMenuConfiguration? { nil }
@@ -199,6 +206,9 @@ public struct AnyCellViewModel: CellViewModel {
     public var shouldHighlight: Bool { self._shouldHighlight }
 
     /// :nodoc:
+    public var children: [AnyCellViewModel] { self._children }
+
+    /// :nodoc:
     public var contextMenuConfiguration: UIContextMenuConfiguration? { self._contextMenuConfiguration }
 
     /// :nodoc:
@@ -251,6 +261,7 @@ public struct AnyCellViewModel: CellViewModel {
     private let _shouldDeselect: Bool
     private let _shouldHighlight: Bool
     private let _contextMenuConfiguration: UIContextMenuConfiguration?
+    private let _children: [AnyCellViewModel]
     private let _configure: @Sendable @MainActor (CellType) -> Void
     private let _didSelect: @Sendable @MainActor (CellEventCoordinator?) -> Void
     private let _didDeselect: @Sendable @MainActor (CellEventCoordinator?) -> Void
@@ -276,6 +287,7 @@ public struct AnyCellViewModel: CellViewModel {
         self._shouldSelect = viewModel.shouldSelect
         self._shouldDeselect = viewModel.shouldDeselect
         self._shouldHighlight = viewModel.shouldHighlight
+        self._children = viewModel.children
         self._contextMenuConfiguration = viewModel.contextMenuConfiguration
         self._configure = {
             viewModel._configureGeneric(cell: $0)

--- a/Sources/CollectionViewDriver.swift
+++ b/Sources/CollectionViewDriver.swift
@@ -328,25 +328,25 @@ extension CollectionViewDriver: UICollectionViewDelegate {
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView,
                                shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        self.viewModel.cellViewModel(at: indexPath).shouldSelect
+        self.viewModel.cellViewModel(at: indexPath, in: collectionView).shouldSelect
     }
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView,
                                didSelectItemAt indexPath: IndexPath) {
-        self.viewModel.cellViewModel(at: indexPath).didSelect(with: self._cellEventCoordinator)
+        self.viewModel.cellViewModel(at: indexPath, in: collectionView).didSelect(with: self._cellEventCoordinator)
     }
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView,
                                shouldDeselectItemAt indexPath: IndexPath) -> Bool {
-        self.viewModel.cellViewModel(at: indexPath).shouldDeselect
+        self.viewModel.cellViewModel(at: indexPath, in: collectionView).shouldDeselect
     }
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView,
                                didDeselectItemAt indexPath: IndexPath) {
-        self.viewModel.cellViewModel(at: indexPath).didDeselect(with: self._cellEventCoordinator)
+        self.viewModel.cellViewModel(at: indexPath, in: collectionView).didDeselect(with: self._cellEventCoordinator)
     }
 
     // MARK: Managing cell highlighting
@@ -354,19 +354,19 @@ extension CollectionViewDriver: UICollectionViewDelegate {
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView,
                                shouldHighlightItemAt indexPath: IndexPath) -> Bool {
-        self.viewModel.cellViewModel(at: indexPath).shouldHighlight
+        self.viewModel.cellViewModel(at: indexPath, in: collectionView).shouldHighlight
     }
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView,
                                didHighlightItemAt indexPath: IndexPath) {
-        self.viewModel.cellViewModel(at: indexPath).didHighlight()
+        self.viewModel.cellViewModel(at: indexPath, in: collectionView).didHighlight()
     }
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView,
                                didUnhighlightItemAt indexPath: IndexPath) {
-        self.viewModel.cellViewModel(at: indexPath).didUnhighlight()
+        self.viewModel.cellViewModel(at: indexPath, in: collectionView).didUnhighlight()
     }
 
     // MARK: Managing context menus
@@ -375,7 +375,7 @@ extension CollectionViewDriver: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView,
                                contextMenuConfigurationForItemAt indexPath: IndexPath,
                                point: CGPoint) -> UIContextMenuConfiguration? {
-        self.viewModel.cellViewModel(at: indexPath).contextMenuConfiguration
+        self.viewModel.cellViewModel(at: indexPath, in: collectionView).contextMenuConfiguration
     }
 
     // MARK: Tracking the addition and removal of views
@@ -384,7 +384,7 @@ extension CollectionViewDriver: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView,
                                willDisplay cell: UICollectionViewCell,
                                forItemAt indexPath: IndexPath) {
-        self.viewModel._safeCellViewModel(at: indexPath)?.willDisplay()
+        self.viewModel._safeCellViewModel(at: indexPath, in: collectionView)?.willDisplay()
     }
 
     /// :nodoc:
@@ -399,7 +399,7 @@ extension CollectionViewDriver: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView,
                                didEndDisplaying cell: UICollectionViewCell,
                                forItemAt indexPath: IndexPath) {
-        self.viewModel._safeCellViewModel(at: indexPath)?.didEndDisplaying()
+        self.viewModel._safeCellViewModel(at: indexPath, in: collectionView)?.didEndDisplaying()
     }
 
     /// :nodoc:

--- a/Sources/DiffableSectionSnapshot.swift
+++ b/Sources/DiffableSectionSnapshot.swift
@@ -1,0 +1,42 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/ReactiveCollectionsKit
+//
+//  GitHub
+//  https://github.com/jessesquires/ReactiveCollectionsKit
+//
+//  Copyright © 2019-present Jesse Squires
+//
+
+import Foundation
+import UIKit
+
+typealias DiffableSectionSnapshot = NSDiffableDataSourceSectionSnapshot<AnyHashable>
+
+extension DiffableSectionSnapshot {
+    init(viewModel: SectionViewModel) {
+        self.init()
+
+        let allCellIdentifiers = viewModel.cells.map(\.id)
+        self.append(allCellIdentifiers)
+
+        viewModel.cells.forEach { cell in
+            appendAllChildren(from: cell, to: cell.id)
+        }
+    }
+
+    private mutating func appendAllChildren(from cell: AnyCellViewModel, to parentId: AnyHashable) {
+        let childIdentifiers = cell.children.map(\.id)
+
+        guard childIdentifiers.isNotEmpty else { return }
+
+        self.append(childIdentifiers, to: parentId)
+
+        for child in cell.children {
+            appendAllChildren(from: child, to: child.id)
+        }
+    }
+}


### PR DESCRIPTION
Issue #33 

## Describe your changes

This is a WIP of an implementation to support nested items (i.e. nested CellViewModels), enabled by `NSDiffableDataSourceSectionSnapshot`s.

**What's been done so far**

1. As discussed in the issue, `CellViewModel` now includes a `children` property, which allows us to provide an array of `AnyCellViewModel`s. Each of those can have `children`, and so on.
2. Created `DiffableSectionSnapshot`, which is a typealias for `NSDiffableDataSourceSectionSnapshot`. The ability to [append items to other items](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesectionsnapshot/3600716-append) is _only_ supported through [section snapshots](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesectionsnapshot). The logic to do so is recursive - appending the items for each top level cell, then for each of those going into all of their children, and so on.
3. Inside `DiffableDataSource`, I added a check to see if we have at least one section with at least one cell that has non-empty children. If that's the case, we split off into creating section snapshots. Otherwise, we proceed with the existing standard snapshot approach.
    - I believe we'll want the same completion logic, so I tried to separate that into a method so as to not repeat all of the comments in there.
4. The final commit is purely for demo purposes, which implements a rough version of some things described below that are still needed + in order to be able to show a quick demo in the example app.

<details>

https://github.com/user-attachments/assets/e4fb5fb1-0546-4861-bc5e-cb2f9538ab2c

</details>

**What still needs to be done**

1. We need to figure out an approach for reconfiguring items for the section snapshots. Section snapshots don't have the same reconfigure APIs as standard snapshots, so my thinking is we'll need to apply all of the section snapshots, then at the end grab the current full snapshot via `self.snapshot()`, then reconfigure from there.
2. We'll need additional recursive logic in `CollectionViewModel` to ensure that we're referencing the snapshot's `visibleItems` when we're grabbing a `CellViewModel` for a given index path. The index paths all change when you expand/collapse an item, so we have to account for that. 
3. Example app work - not sure if want that in this PR or a separate one.
4. Perhaps some additional/updated comments
5. Tests