### PR TITLE
Drop support for iOS 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NEXT
 
 This release closes the [0.1.9 milestone](https://github.com/jessesquires/ReactiveCollectionsKit/milestone/2?closed=1).
 
+- Drop support for iOS 15. **Minimum iOS 16 now required.**
 - Fixed a (potential) bug where cells with the same name, but in different modules, would provide the same (conflicting) default `reuseIdentifier`. Default `reuseIdentifiers` now return the fully qualified type name. ([@jessesquires](https://github.com/jessesquires), [#150](https://github.com/jessesquires/ReactiveCollectionsKit/issues/150), [#154](https://github.com/jessesquires/ReactiveCollectionsKit/pull/154))
     - Previous behavior: `"MyCellClassName"`
     - New behavior: `"MyModuleName.MyCellClassName"`

--- a/Example/ExampleApp.xcodeproj/project.pbxproj
+++ b/Example/ExampleApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 90;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -38,14 +38,12 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		0B31B9B72BCC63D4006F2078 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
 			dstPath = "";
-			dstSubfolderSpec = 10;
+			dstSubfolder = Frameworks;
 			files = (
 				0B31B9B62BCC63D4006F2078 /* ReactiveCollectionsKit.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -117,25 +115,19 @@
 /* Begin PBXFrameworksBuildPhase section */
 		0B31B9382BCC62A4006F2078 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				0B31B9B52BCC63D4006F2078 /* ReactiveCollectionsKit.framework in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0B31B94E2BCC62A5006F2078 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0B31B9582BCC62A5006F2078 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -189,8 +181,6 @@
 				0B31B9B72BCC63D4006F2078 /* Embed Frameworks */,
 			);
 			buildRules = (
-			);
-			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
 				0B8701882CAE1D980098CB29 /* Sources */,
@@ -269,7 +259,7 @@
 			);
 			mainGroup = 0B31B9322BCC62A4006F2078;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
+			preferredProjectObjectVersion = 90;
 			productRefGroup = 0B31B93C2BCC62A4006F2078 /* Products */;
 			projectDirPath = "";
 			projectReferences = (
@@ -300,48 +290,36 @@
 /* Begin PBXResourcesBuildPhase section */
 		0B31B9392BCC62A4006F2078 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0B31B94F2BCC62A5006F2078 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0B31B9592BCC62A5006F2078 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		0B31B9372BCC62A4006F2078 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0B31B94D2BCC62A5006F2078 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0B31B9572BCC62A5006F2078 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -359,7 +337,7 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		0B31B9632BCC62A5006F2078 /* Debug */ = {
+		0B31B9632BCC62A5006F2078 /* Debug configuration for PBXProject "ExampleApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -415,7 +393,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -430,7 +408,7 @@
 			};
 			name = Debug;
 		};
-		0B31B9642BCC62A5006F2078 /* Release */ = {
+		0B31B9642BCC62A5006F2078 /* Release configuration for PBXProject "ExampleApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -480,7 +458,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -494,7 +472,7 @@
 			};
 			name = Release;
 		};
-		0B31B9662BCC62A5006F2078 /* Debug */ = {
+		0B31B9662BCC62A5006F2078 /* Debug configuration for PBXNativeTarget "ExampleApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -524,7 +502,7 @@
 			};
 			name = Debug;
 		};
-		0B31B9672BCC62A5006F2078 /* Release */ = {
+		0B31B9672BCC62A5006F2078 /* Release configuration for PBXNativeTarget "ExampleApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -554,7 +532,7 @@
 			};
 			name = Release;
 		};
-		0B31B9692BCC62A5006F2078 /* Debug */ = {
+		0B31B9692BCC62A5006F2078 /* Debug configuration for PBXNativeTarget "ExampleAppTests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -573,7 +551,7 @@
 			};
 			name = Debug;
 		};
-		0B31B96A2BCC62A5006F2078 /* Release */ = {
+		0B31B96A2BCC62A5006F2078 /* Release configuration for PBXNativeTarget "ExampleAppTests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -592,7 +570,7 @@
 			};
 			name = Release;
 		};
-		0B31B96C2BCC62A5006F2078 /* Debug */ = {
+		0B31B96C2BCC62A5006F2078 /* Debug configuration for PBXNativeTarget "ExampleAppUITests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
@@ -610,7 +588,7 @@
 			};
 			name = Debug;
 		};
-		0B31B96D2BCC62A5006F2078 /* Release */ = {
+		0B31B96D2BCC62A5006F2078 /* Release configuration for PBXNativeTarget "ExampleAppUITests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
@@ -634,37 +612,33 @@
 		0B31B9362BCC62A4006F2078 /* Build configuration list for PBXProject "ExampleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0B31B9632BCC62A5006F2078 /* Debug */,
-				0B31B9642BCC62A5006F2078 /* Release */,
+				0B31B9632BCC62A5006F2078 /* Debug configuration for PBXProject "ExampleApp" */,
+				0B31B9642BCC62A5006F2078 /* Release configuration for PBXProject "ExampleApp" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		0B31B9652BCC62A5006F2078 /* Build configuration list for PBXNativeTarget "ExampleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0B31B9662BCC62A5006F2078 /* Debug */,
-				0B31B9672BCC62A5006F2078 /* Release */,
+				0B31B9662BCC62A5006F2078 /* Debug configuration for PBXNativeTarget "ExampleApp" */,
+				0B31B9672BCC62A5006F2078 /* Release configuration for PBXNativeTarget "ExampleApp" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		0B31B9682BCC62A5006F2078 /* Build configuration list for PBXNativeTarget "ExampleAppTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0B31B9692BCC62A5006F2078 /* Debug */,
-				0B31B96A2BCC62A5006F2078 /* Release */,
+				0B31B9692BCC62A5006F2078 /* Debug configuration for PBXNativeTarget "ExampleAppTests" */,
+				0B31B96A2BCC62A5006F2078 /* Release configuration for PBXNativeTarget "ExampleAppTests" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		0B31B96B2BCC62A5006F2078 /* Build configuration list for PBXNativeTarget "ExampleAppUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0B31B96C2BCC62A5006F2078 /* Debug */,
-				0B31B96D2BCC62A5006F2078 /* Release */,
+				0B31B96C2BCC62A5006F2078 /* Debug configuration for PBXNativeTarget "ExampleAppUITests" */,
+				0B31B96D2BCC62A5006F2078 /* Release configuration for PBXNativeTarget "ExampleAppUITests" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */

--- a/Example/Sources/Grid/GridViewController.swift
+++ b/Example/Sources/Grid/GridViewController.swift
@@ -89,16 +89,18 @@ final class GridViewController: ExampleViewController, CellEventCoordinator {
 
         // Item
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                              heightDimension: .fractionalHeight(1.0))
+                                              heightDimension: .fractionalHeight(0.5))
         let item = NSCollectionLayoutItem(layoutSize: itemSize, supplementaryItems: [badge])
         item.contentInsets = NSDirectionalEdgeInsets(top: inset, leading: inset, bottom: inset, trailing: inset)
 
         // Group
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5),
                                                heightDimension: .fractionalHeight(0.5))
-        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize,
-                                                     subitem: item,
-                                                     count: 2)
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            repeatingSubitem: item,
+            count: 2
+        )
 
         // Headers and Footers
         let headerFooterSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ import PackageDescription
 let package = Package(
     name: "ReactiveCollectionsKit",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v16)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ driver.update(viewModel: updated)
 
 ## Requirements
 
-- iOS 15.0+
+- iOS 16.0+
 - Swift 5.10+
 - Xcode 26.0+
 - [SwiftLint](https://github.com/realm/SwiftLint)

--- a/ReactiveCollectionsKit.xcodeproj/project.pbxproj
+++ b/ReactiveCollectionsKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 90;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -54,18 +54,14 @@
 /* Begin PBXFrameworksBuildPhase section */
 		88FA48D72363A6160061F8B2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		88FA48E02363A6160061F8B2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				88FA48E42363A6160061F8B2 /* ReactiveCollectionsKit.framework in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -93,10 +89,8 @@
 /* Begin PBXHeadersBuildPhase section */
 		88FA48D52363A6160061F8B2 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
@@ -112,8 +106,6 @@
 				88FA49242363AF790061F8B2 /* Run SwiftLint */,
 			);
 			buildRules = (
-			);
-			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
 				0B8700FA2CAE1D810098CB29 /* Sources */,
@@ -152,7 +144,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1110;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 2610;
 				ORGANIZATIONNAME = "Hexed Bits";
 				TargetAttributes = {
 					88FA48D92363A6160061F8B2 = {
@@ -173,7 +165,7 @@
 			);
 			mainGroup = 88FA48D02363A6160061F8B2;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
+			preferredProjectObjectVersion = 90;
 			productRefGroup = 88FA48DB2363A6160061F8B2 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -187,17 +179,13 @@
 /* Begin PBXResourcesBuildPhase section */
 		88FA48D82363A6160061F8B2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		88FA48E12363A6160061F8B2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
@@ -205,38 +193,25 @@
 		88FA49242363AF790061F8B2 /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
 			name = "Run SwiftLint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/zsh;
-			shellScript = "\"${SRCROOT}/scripts/lint.zsh\"\n";
+			shellScript = (
+				"\"${SRCROOT}/scripts/lint.zsh\"",
+				"",
+			);
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		88FA48D62363A6160061F8B2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		88FA48DF2363A6160061F8B2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -249,7 +224,7 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		88FA48EC2363A6160061F8B2 /* Debug */ = {
+		88FA48EC2363A6160061F8B2 /* Debug configuration for PBXProject "ReactiveCollectionsKit" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -303,12 +278,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -318,7 +294,7 @@
 			};
 			name = Debug;
 		};
-		88FA48ED2363A6160061F8B2 /* Release */ = {
+		88FA48ED2363A6160061F8B2 /* Release configuration for PBXProject "ReactiveCollectionsKit" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -366,11 +342,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -381,7 +358,7 @@
 			};
 			name = Release;
 		};
-		88FA48EF2363A6160061F8B2 /* Debug */ = {
+		88FA48EF2363A6160061F8B2 /* Debug configuration for PBXNativeTarget "ReactiveCollectionsKit" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -415,7 +392,7 @@
 			};
 			name = Debug;
 		};
-		88FA48F02363A6160061F8B2 /* Release */ = {
+		88FA48F02363A6160061F8B2 /* Release configuration for PBXNativeTarget "ReactiveCollectionsKit" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -448,7 +425,7 @@
 			};
 			name = Release;
 		};
-		88FA48F22363A6160061F8B2 /* Debug */ = {
+		88FA48F22363A6160061F8B2 /* Debug configuration for PBXNativeTarget "ReactiveCollectionsKitTests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -471,7 +448,7 @@
 			};
 			name = Debug;
 		};
-		88FA48F32363A6160061F8B2 /* Release */ = {
+		88FA48F32363A6160061F8B2 /* Release configuration for PBXNativeTarget "ReactiveCollectionsKitTests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -500,28 +477,25 @@
 		88FA48D42363A6160061F8B2 /* Build configuration list for PBXProject "ReactiveCollectionsKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				88FA48EC2363A6160061F8B2 /* Debug */,
-				88FA48ED2363A6160061F8B2 /* Release */,
+				88FA48EC2363A6160061F8B2 /* Debug configuration for PBXProject "ReactiveCollectionsKit" */,
+				88FA48ED2363A6160061F8B2 /* Release configuration for PBXProject "ReactiveCollectionsKit" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		88FA48EE2363A6160061F8B2 /* Build configuration list for PBXNativeTarget "ReactiveCollectionsKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				88FA48EF2363A6160061F8B2 /* Debug */,
-				88FA48F02363A6160061F8B2 /* Release */,
+				88FA48EF2363A6160061F8B2 /* Debug configuration for PBXNativeTarget "ReactiveCollectionsKit" */,
+				88FA48F02363A6160061F8B2 /* Release configuration for PBXNativeTarget "ReactiveCollectionsKit" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		88FA48F12363A6160061F8B2 /* Build configuration list for PBXNativeTarget "ReactiveCollectionsKitTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				88FA48F22363A6160061F8B2 /* Debug */,
-				88FA48F32363A6160061F8B2 /* Release */,
+				88FA48F22363A6160061F8B2 /* Debug configuration for PBXNativeTarget "ReactiveCollectionsKitTests" */,
+				88FA48F32363A6160061F8B2 /* Release configuration for PBXNativeTarget "ReactiveCollectionsKitTests" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */


### PR DESCRIPTION
Drop support for iOS 15. **Minimum iOS 16 now required.**

Also update Xcode 26 settings.