### PR TITLE
Fixed spacing typo in `AnyCellViewModel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ NEXT
 
 - TBA
 
+0.2.1
+-----
+
+- Fixed a breaking syntax typo that was previously allowed under prior versions of the Swift compiler. ([@timoliver](https://github.com/timoliver), [#160](https://github.com/jessesquires/ReactiveCollectionsKit/pull/160))
+
 0.2.0
 -----
 

--- a/Sources/CellViewModel.swift
+++ b/Sources/CellViewModel.swift
@@ -256,7 +256,7 @@ public struct AnyCellViewModel: CellViewModel {
     private let _didDeselect: @Sendable @MainActor (CellEventCoordinator?) -> Void
     private let _willDisplay: @Sendable @MainActor () -> Void
     private let _didEndDisplaying: @Sendable @MainActor () -> Void
-    private let _didHighlight: @Sendable @MainActor() -> Void
+    private let _didHighlight: @Sendable @MainActor () -> Void
     private let _didUnhighlight: @Sendable @MainActor () -> Void
 
     // MARK: Init


### PR DESCRIPTION
G'day @jessesquires! Long time no see! I hope you've been well!

I'm out of Instagram now, but after using IGListKit for so long, I'm interested in using a similar, more modern library in my own libraries. Thanks so much for carrying on the IGListKit legacy. :)

Quick and easy PR! I just discovered a build error in the latest version of Xcode. It looks like the Swift compiler has gotten more strict in recent times, and it decided to stop letting this typo through. Hope this helps!

<img width="1193" height="205" alt="Screenshot 2026-04-24 at 15 32 47" src="https://github.com/user-attachments/assets/f046720d-3695-44de-91fc-e838c5b00ecf" />
